### PR TITLE
Update to reflect changed structure of vocabulary-icon element.

### DIFF
--- a/WaniKani Pitch Info.js
+++ b/WaniKani Pitch Info.js
@@ -217,7 +217,7 @@ function parsePage(forceRefresh) {
     //Check for Vocab page element
     var vocabIcon = document.getElementsByClassName('vocabulary-icon')[0];
     if (vocabIcon != null) {
-      tmpVocab = $(vocabIcon.getElementsByTagName('span')[0]).html();
+      tmpVocab = vocabIcon.innerHTML;
       tmpSessionElem = document.getElementsByClassName('vocabulary-reading')[0];
     }
   }


### PR DESCRIPTION
See [this forum post](https://community.wanikani.com/t/userscript-wanikani-pitch-info/18745/188?u=nleseul). The script isn't currently detecting the vocabulary term correctly on vocabulary pages. This fixes it.