### PR TITLE
Fix line-drawing bug

### DIFF
--- a/WaniKani Pitch Info.js
+++ b/WaniKani Pitch Info.js
@@ -516,7 +516,7 @@ function drawPitchDiagram(pitchNum, patternType) {
     c++;
   }
   // draw lines between points
-  for (var l = 0; l < points.length - l; l++) {
+  for (var l = 0; l < points.length - 1; l++) {
     drawLine(points[l].x, points[l].y, points[l + 1].x, points[l + 1].y);
   }
   // draw circles at points


### PR DESCRIPTION
Looping while `L < points.length - L` (uppercase L for emphasis) will draw only half of the lines, causing output like this. The second `L` should be a `1` (one).

![image](https://user-images.githubusercontent.com/16232127/88982932-de6a7680-d2c9-11ea-985f-41a2a0f25bcc.png)
