### PR TITLE
Fix extra readings

### DIFF
--- a/WaniKani Pitch Info.user.js
+++ b/WaniKani Pitch Info.user.js
@@ -3,7 +3,7 @@
 // @match        https://www.wanikani.com/*
 // @match        https://preview.wanikani.com/*
 // @namespace    https://greasyfork.org/en/scripts/31070-wanikani-pitch-info
-// @version      0.80
+// @version      0.81
 // @description  Displays pitch accent diagrams on WaniKani vocab and session pages.
 // @author       Invertex
 // @supportURL   http://invertex.xyz
@@ -135,13 +135,8 @@ var wkof = null;
           // Check if pitch info has already been added to avoid duplicates
           if (divQuestion.querySelector('.question-pitch-display')) return;
 
-          // Find out the readings from Wanikani
-          const quizInput = Stimulus.getControllerForElementAndIdentifier(document.querySelector('[data-controller~="quiz-input"]'), 'quiz-input');
-          const wkReadings = quizInput?.currentSubject?.readings;
-          if (!wkReadings) return;
-
           // For each reading, add the pitch into the area next to the question
-          for (const wkReading of wkReadings) {
+          for (const reading of wkItemInfo.currentState.reading) {
             const reading = wkReading.text;
             console.log(`reading: ${reading}`);
             if (!reading) continue;

--- a/WaniKani Pitch Info.user.js
+++ b/WaniKani Pitch Info.user.js
@@ -137,7 +137,6 @@ var wkof = null;
 
           // For each reading, add the pitch into the area next to the question
           for (const reading of wkItemInfo.currentState.reading) {
-            const reading = wkReading.text;
             console.log(`reading: ${reading}`);
             if (!reading) continue;
 


### PR DESCRIPTION
## Problem

Sometimes, extra readings might appear.

This is caused by my previous commit, which was written before wanikani-item-info-injector was fixed.
Sorry about that.
```
// Find out the readings from Wanikani
const quizInput = Stimulus.getControllerForElementAndIdentifier(document.querySelector('[data-controller~="quiz-input"]'), 'quiz-input');
const wkReadings = quizInput?.currentSubject?.readings;
if (!wkReadings) return;
// For each reading, add the pitch into the area next to the question
for (const wkReading of wkReadings) {
```

## Solution
* Just undo the portion - the latest version of wanikani-item-info-injector is fixed, and we won't show "undefined".
* Or, implement extra checks in the raw readings obtained from wanikani. (It's already done by wanikani-item-info-injector)


