### PR TITLE
Fix Question Pitch Display for Nov 2025

### DIFF
--- a/WaniKani Pitch Info.user.js
+++ b/WaniKani Pitch Info.user.js
@@ -128,39 +128,39 @@ var wkof = null;
 
       // didAnswerQuestion will be triggered whenever the user answers a question
       window.addEventListener('didAnswerQuestion', () => {
-        console.log('didAnswerQuestion');
+        console.debug('didAnswerQuestion');
 
         // Only display pitch next to the question if the user enables it in the settings.
         if (wkof.settings.wanikani_pitch_info?.display_pitch_beside_question) {
           // Make sure that this is a vocab reading review
           if (!(wkItemInfo.currentState.on == 'review' && wkItemInfo.currentState.type == 'vocabulary' && wkItemInfo.currentState.under.includes('reading'))) {
-            console.log('Not vocab reading review. Ignoring.');
+            console.debug('Not vocab reading review. Ignoring.');
             return;
           }
 
           // Figure out whether the answer is correct. Don't display the pitch if the answer is wrong.
           const userAnswer = document.querySelector('#user-response')?.value?.trim();
           if (!wkItemInfo.currentState.reading.includes(userAnswer)) {
-            console.log('User answer is wrong. Not displaying pitch.');
+            console.debug('User answer is wrong. Not displaying pitch.');
             return;
           }
 
           // Locate the html element where we want to insert our pitch after
           let divQuestion = document.querySelector('div.character-header__characters');
           if (!divQuestion) {
-            console.log('Unable to locate divQuestion.');
+            console.error('Unable to locate divQuestion.');
             return;
           }
 
           // Check if pitch info has already been added to avoid duplicates
           if (divQuestion.querySelector('.question-pitch-display')) {
-            console.log('Pitch info already added. Ignoring.');
+            console.debug('Pitch info already added. Ignoring.');
             return;
           }
 
           // For each reading, add the pitch into the area next to the question
           for (const reading of wkItemInfo.currentState.reading) {
-            console.log(`reading: ${reading}`);
+            console.debug(`reading: ${reading}`);
             if (!reading) continue;
 
             // Create a white box in the question area

--- a/WaniKani Pitch Info.user.js
+++ b/WaniKani Pitch Info.user.js
@@ -146,7 +146,7 @@ var wkof = null;
           }
 
           // Locate the html element where we want to insert our pitch after
-          let divQuestion = document.querySelector('.character-header__characters');
+          let divQuestion = document.querySelector('div.character-header__characters');
           if (!divQuestion) {
             console.log('Unable to locate divQuestion.');
             return;

--- a/WaniKani Pitch Info.user.js
+++ b/WaniKani Pitch Info.user.js
@@ -128,33 +128,33 @@ var wkof = null;
 
       // didAnswerQuestion will be triggered whenever the user answers a question
       window.addEventListener('didAnswerQuestion', () => {
-        console.log("didAnswerQuestion");
+        console.log('didAnswerQuestion');
 
         // Only display pitch next to the question if the user enables it in the settings.
         if (wkof.settings.wanikani_pitch_info?.display_pitch_beside_question) {
           // Make sure that this is a vocab reading review
-          if (!(wkItemInfo.currentState.on == "review" && wkItemInfo.currentState.type == "vocabulary" && wkItemInfo.currentState.under.includes("reading"))) {
+          if (!(wkItemInfo.currentState.on == 'review' && wkItemInfo.currentState.type == 'vocabulary' && wkItemInfo.currentState.under.includes('reading'))) {
             console.log('Not vocab reading review. Ignoring.');
             return;
           }
 
           // Figure out whether the answer is correct. Don't display the pitch if the answer is wrong.
-          const userAnswer = document.querySelector("#user-response")?.value?.trim();
+          const userAnswer = document.querySelector('#user-response')?.value?.trim();
           if (!wkItemInfo.currentState.reading.includes(userAnswer)) {
-            console.log("User answer is wrong. Not displaying pitch.");
+            console.log('User answer is wrong. Not displaying pitch.');
             return;
           }
 
           // Locate the html element where we want to insert our pitch after
-          let divQuestion = document.querySelector(".character-header__characters");
+          let divQuestion = document.querySelector('.character-header__characters');
           if (!divQuestion) {
-            console.log("Unable to locate divQuestion.");
+            console.log('Unable to locate divQuestion.');
             return;
           }
 
           // Check if pitch info has already been added to avoid duplicates
           if (divQuestion.querySelector('.question-pitch-display')) {
-            console.log("Pitch info already added. Ignoring.");
+            console.log('Pitch info already added. Ignoring.');
             return;
           }
 
@@ -164,11 +164,11 @@ var wkof = null;
             if (!reading) continue;
 
             // Create a white box in the question area
-            var divOuter = document.createElement("div");
+            var divOuter = document.createElement('div');
             divOuter.setAttribute('class', 'additional-content__content additional-content__content--open subject-section subject-section--reading subject-section--collapsible subject-section__subsection subject-readings-with-audio subject-readings-with-audio__item');
 
             // Create a div to store the reading
-            var divReading = document.createElement("div");
+            var divReading = document.createElement('div');
             divReading.setAttribute('class', 'reading-with-audio__reading question-pitch-display');
             divReading.setAttribute('lang', 'ja');
             divReading.innerHTML = `${reading}`;

--- a/WaniKani Pitch Info.user.js
+++ b/WaniKani Pitch Info.user.js
@@ -3,7 +3,7 @@
 // @match        https://www.wanikani.com/*
 // @match        https://preview.wanikani.com/*
 // @namespace    https://greasyfork.org/en/scripts/31070-wanikani-pitch-info
-// @version      0.83
+// @version      0.84
 // @description  Displays pitch accent diagrams on WaniKani vocab and session pages.
 // @author       Invertex
 // @supportURL   http://invertex.xyz


### PR DESCRIPTION
It was broken after WaniKani updated.

## 1. The didAnswerQuestion event callback no longer returns a parameter with details about the user's choice.

Code Snippet:
```
window.addEventListener('didAnswerQuestion', (ev) => {
  console.log("didAnswerQuestion");
  // didAnswerQuestion will be triggered whenever the user answers a question
  console.log(`ev: ${JSON.stringify(ev)}`);
  
  if (wkof.settings.wanikani_pitch_info?.display_pitch_beside_question && ev.detail.questionType == 'reading' && ev.detail.results.action == 'pass') {
  ...
```

Problem: `ev` is now empty.
So, all of the for `ev.detail.questionType` and `ev.detail.results.action` always failed.

See https://community.wanikani.com/t/userscripting-question-how-to-determine-correctness-of-users-answer-in-didanswerquestion/72552


## 2. The query selector string of divQuestion has changed and no longer works.

Before: `let divQuestion = document.querySelector("#turbo-body > div.quiz > div > div.character-header.character-header--vocabulary > div > div.qa-character-wrapper > div.character-header__characters");`
Updated: `let divQuestion = document.querySelector('div.character-header__characters');`

Hopefully, the new selector is more resilient.
There wasn't really a need to search all the way from #turbo-body.

